### PR TITLE
Renaming `Result` to `Output` in the C API

### DIFF
--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -11,8 +11,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 FetchContent_Declare(
   regocpp
-  GIT_REPOSITORY https://github.com/microsoft/rego-cpp
-  GIT_TAG        main
+  GIT_REPOSITORY https://github.com/matajoh/rego-cpp
+  GIT_TAG        19edb113037c163978d301d1db252cf4ce37140f
 )
 
 FetchContent_Declare(

--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -198,7 +198,7 @@ int main(int argc, char** argv)
     .query = NULL};
   unsigned int data_index;
   regoInterpreter* rego = NULL;
-  regoResult* result = NULL;
+  regoOutput* output = NULL;
   int rc = EXIT_SUCCESS;
   regoEnum err;
 
@@ -286,19 +286,19 @@ int main(int argc, char** argv)
     }
   }
 
-  result = regoQuery(rego, config.query);
-  if (result == NULL)
+  output = regoQuery(rego, config.query);
+  if (output == NULL)
   {
     goto error;
   }
   if (config.use_raw_query)
   {
-    print_node(regoResultNode(result), 0);
+    print_node(regoOutputNode(output), 0);
     goto exit;
   }
   else
   {
-    printf("%s\n", regoResultString(result));
+    printf("%s\n", regoOutputString(output));
     goto exit;
   }
 
@@ -307,9 +307,9 @@ error:
   rc = EXIT_FAILURE;
 
 exit:
-  if (result != NULL)
+  if (output != NULL)
   {
-    regoFreeResult(result);
+    regoFreeOutput(output);
   }
 
   if (rego != NULL)

--- a/include/rego/interpreter.h
+++ b/include/rego/interpreter.h
@@ -42,10 +42,10 @@ namespace rego
   private:
     friend const char* ::regoGetError(regoInterpreter* rego);
     friend void setError(regoInterpreter* rego, const std::string& error);
-    friend regoResult* ::regoQuery(
+    friend regoOutput* ::regoQuery(
       regoInterpreter* rego, const char* query_expr);
 
-    std::string result_to_string(const Node& result) const;
+    std::string output_to_string(const Node& output) const;
     void write_ast(
       std::size_t index, const std::string& pass, const Node& ast) const;
     Node get_errors(const Node& ast) const;

--- a/include/rego/rego_c.h
+++ b/include/rego/rego_c.h
@@ -8,7 +8,7 @@
 
 typedef void regoInterpreter;
 typedef void regoNode;
-typedef void regoResult;
+typedef void regoOutput;
 typedef unsigned int regoEnum;
 typedef unsigned char regoBoolean;
 typedef unsigned int regoSize;
@@ -64,15 +64,15 @@ extern "C"
     regoInterpreter* rego, regoBoolean enabled);
   regoBoolean regoGetWellFormedChecksEnabled(regoInterpreter* rego);
   void regoSetExecutable(regoInterpreter* rego, const char* path);
-  regoResult* regoQuery(regoInterpreter* rego, const char* query_expr);
+  regoOutput* regoQuery(regoInterpreter* rego, const char* query_expr);
   const char* regoGetError(regoInterpreter* rego);
 
-  // Result functions
-  regoBoolean regoResultOk(regoResult* result);
-  regoNode* regoResultNode(regoResult* result);
-  regoNode* regoResultBinding(regoResult* result, const char* name);
-  const char* regoResultString(regoResult* result);
-  void regoFreeResult(regoResult* result);
+  // Output functions
+  regoBoolean regoOutputOk(regoOutput* output);
+  regoNode* regoOutputNode(regoOutput* output);
+  regoNode* regoOutputBinding(regoOutput* output, const char* name);
+  const char* regoOutputString(regoOutput* output);
+  void regoFreeOutput(regoOutput* output);
 
   // Node functions
   regoEnum regoNodeType(regoNode* node);

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -215,36 +215,36 @@ namespace rego
 
   std::string Interpreter::query(const std::string& query_expr) const
   {
-    return result_to_string(raw_query(query_expr));
+    return output_to_string(raw_query(query_expr));
   }
 
-  std::string Interpreter::result_to_string(const Node& ast) const
+  std::string Interpreter::output_to_string(const Node& ast) const
   {
-    std::ostringstream result_buf;
+    std::ostringstream output_buf;
     if (ast->type() == ErrorSeq)
     {
-      result_buf << "errors:" << std::endl;
+      output_buf << "errors:" << std::endl;
 
       for (auto& error : *ast)
       {
         Node error_ast = error / ErrorAst;
-        result_buf << "---" << std::endl;
-        result_buf << "error: " << (error / ErrorMsg)->location().view()
+        output_buf << "---" << std::endl;
+        output_buf << "error: " << (error / ErrorMsg)->location().view()
                    << std::endl;
-        result_buf << "code: " << (error / ErrorCode)->location().view()
+        output_buf << "code: " << (error / ErrorCode)->location().view()
                    << std::endl;
-        result_buf << error_ast;
+        output_buf << error_ast;
       }
     }
     else
     {
       for (auto result : *ast)
       {
-        result_buf << rego::to_json(result) << std::endl;
+        output_buf << rego::to_json(result) << std::endl;
       }
     }
 
-    return result_buf.str();
+    return output_buf.str();
   }
 
   Interpreter& Interpreter::debug_path(const std::filesystem::path& path)

--- a/src/rego_c.cc
+++ b/src/rego_c.cc
@@ -11,7 +11,7 @@ namespace rego
     reinterpret_cast<rego::Interpreter*>(rego)->m_c_error = error;
   }
 
-  struct RegoResult
+  struct regoOutput
   {
     Node node;
     std::string value;
@@ -158,16 +158,16 @@ extern "C"
     reinterpret_cast<rego::Interpreter*>(rego)->executable(path);
   }
 
-  regoResult* regoQuery(regoInterpreter* rego, const char* query_expr)
+  regoOutput* regoQuery(regoInterpreter* rego, const char* query_expr)
   {
     try
     {
       auto interpreter = reinterpret_cast<rego::Interpreter*>(rego);
-      rego::RegoResult* result = new rego::RegoResult();
-      result->node = interpreter->raw_query(query_expr);
-      result->value = interpreter->result_to_string(result->node);
+      rego::regoOutput* output = new rego::regoOutput();
+      output->node = interpreter->raw_query(query_expr);
+      output->value = interpreter->output_to_string(output->node);
 
-      return reinterpret_cast<regoResult*>(result);
+      return reinterpret_cast<regoOutput*>(output);
     }
     catch (const std::exception& e)
     {
@@ -176,23 +176,23 @@ extern "C"
     }
   }
 
-  // Result functions
-  regoBoolean regoResultOk(regoResult* result)
+  // Output functions
+  regoBoolean regoOutputOk(regoOutput* output)
   {
-    return reinterpret_cast<rego::RegoResult*>(result)->node->type() !=
+    return reinterpret_cast<rego::regoOutput*>(output)->node->type() !=
       rego::ErrorSeq;
   }
 
-  regoNode* regoResultNode(regoResult* result)
+  regoNode* regoOutputNode(regoOutput* output)
   {
     return reinterpret_cast<regoNode*>(
-      reinterpret_cast<rego::RegoResult*>(result)->node.get());
+      reinterpret_cast<rego::regoOutput*>(output)->node.get());
   }
 
-  regoNode* regoResultBinding(regoResult* result, const char* name)
+  regoNode* regoOutputBinding(regoOutput* output, const char* name)
   {
-    auto result_ptr = reinterpret_cast<rego::RegoResult*>(result);
-    auto node_ptr = reinterpret_cast<trieste::NodeDef*>(result_ptr->node.get());
+    auto output_ptr = reinterpret_cast<rego::regoOutput*>(output);
+    auto node_ptr = reinterpret_cast<trieste::NodeDef*>(output_ptr->node.get());
     if (node_ptr->type() == rego::ErrorSeq)
     {
       return nullptr;
@@ -211,14 +211,14 @@ extern "C"
     return nullptr;
   }
 
-  const char* regoResultString(regoResult* result)
+  const char* regoOutputString(regoOutput* output)
   {
-    return reinterpret_cast<rego::RegoResult*>(result)->value.c_str();
+    return reinterpret_cast<rego::regoOutput*>(output)->value.c_str();
   }
 
-  void regoFreeResult(regoResult* result)
+  void regoFreeOutput(regoOutput* output)
   {
-    delete reinterpret_cast<rego::RegoResult*>(result);
+    delete reinterpret_cast<rego::regoOutput*>(output);
   }
 
   // Node functions


### PR DESCRIPTION
Having something called `Result` causes confusion in some languages (e.g. Rust) so for clarity we're renaming to `Output`. This is also more inline with OPA naming conventions.