### PR TITLE
Moving to newer trieste

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG        861f35e379b5ae0908cbb7b4b4e844fee036cb35
+  GIT_TAG        e8bf084a1f9275580db77624df031e500c910f10
 )
 
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG        15918c8c68d2a4fd5862ca05420729126cdfe7f2
+  GIT_TAG        0b2ec3c5ea7bf52b0f6b2ed9e4f9d571aba47a8b
 )
 
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG        e8bf084a1f9275580db77624df031e500c910f10
+  GIT_TAG        15918c8c68d2a4fd5862ca05420729126cdfe7f2
 )
 
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW) 

--- a/include/rego/rego.hh
+++ b/include/rego/rego.hh
@@ -1317,6 +1317,11 @@ namespace rego
   Parse parser();
 
   /**
+   * @return std::vector<Pass> that is used to process a rego query.
+   */
+  std::vector<Pass> passes();
+
+  /**
    * Returns a node representing the version of the library.
    *
    * The resulting node will be an object containing:

--- a/include/rego/rego.hh
+++ b/include/rego/rego.hh
@@ -1319,7 +1319,7 @@ namespace rego
   /**
    * @return std::vector<Pass> that is used to process a rego query.
    */
-  std::vector<Pass> passes();
+  std::vector<Pass> passes(const BuiltIns& builtins);
 
   /**
    * Returns a node representing the version of the library.

--- a/include/rego/rego.hh
+++ b/include/rego/rego.hh
@@ -5,7 +5,7 @@
 
 #include "rego_c.h"
 
-#include <trieste/driver.h>
+#include <trieste/trieste.h>
 
 /**
  *  This namespace provides the C++ API for the library.
@@ -1317,19 +1317,6 @@ namespace rego
   Parse parser();
 
   /**
-   * Creates a test driver.
-   *
-   * The test driver performs probabilstic testing of the complication. For each
-   * pass it generates random AST outputs depending on the well-formed
-   * expression of the input, runs them through the pass logic, and then checks
-   * it against the wf expression for the output.
-   *
-   * @param builtins The built-ins to use.
-   * @return The driver.
-   */
-  Driver& driver(const BuiltIns& builtins);
-
-  /**
    * Returns a node representing the version of the library.
    *
    * The resulting node will be an object containing:
@@ -1545,6 +1532,11 @@ namespace rego
     BuiltIns& builtins();
     const BuiltIns& builtins() const;
 
+    /**
+     * The well-formedness of the output Ast from the interpreter.
+     */
+    const trieste::wf::Wellformed& output_wf() const;
+
   private:
     friend const char* ::regoGetError(regoInterpreter* rego);
     friend void setError(regoInterpreter* rego, const std::string& error);
@@ -1553,9 +1545,6 @@ namespace rego
 
     void insert_module(const Node& module);
     std::string output_to_string(const Node& output) const;
-    void write_ast(
-      std::size_t index, const std::string& pass, const Node& ast) const;
-    Node get_errors(const Node& ast) const;
     Parse m_parser;
     Node m_module_seq;
     Node m_data_seq;

--- a/src/internal.hh
+++ b/src/internal.hh
@@ -9,8 +9,6 @@
 
 namespace rego
 {
-  std::vector<Pass> passes(const BuiltIns& builtins);
-
   const inline auto ScalarToken =
     T(Int) / T(Float) / T(True) / T(False) / T(Null);
   const inline auto ArithToken =

--- a/src/rego.cc
+++ b/src/rego.cc
@@ -54,12 +54,6 @@ namespace rego
     };
   }
 
-  Driver& driver(const BuiltIns& builtins)
-  {
-    static Driver d("rego", nullptr, parser(), passes(builtins));
-    return d;
-  }
-
   void set_log_level(LogLevel level)
   {
     // Set trieste LogLevel

--- a/tests/driver.cc
+++ b/tests/driver.cc
@@ -1,6 +1,10 @@
+#include "trieste/driver.h"
+
 #include "rego_test.h"
 
 int main(int argc, char** argv)
 {
-  return rego_test::driver().run(argc, argv);
+  trieste::Driver driver(
+    "rego_test", nullptr, rego_test::parser(), rego_test::passes());
+  return driver.run(argc, argv);
 }

--- a/tests/rego_test.cc
+++ b/tests/rego_test.cc
@@ -483,9 +483,4 @@ namespace rego_test
       structure(),
       to_rego()};
   }
-  Driver& driver()
-  {
-    static Driver d("rego_test", nullptr, parser(), passes());
-    return d;
-  }
 }

--- a/tests/rego_test.h
+++ b/tests/rego_test.h
@@ -162,6 +162,5 @@ namespace rego_test
   }
 
   Parse parser();
-  Driver& driver();
   std::vector<Pass> passes();
 }

--- a/tests/test_case.h
+++ b/tests/test_case.h
@@ -88,11 +88,6 @@ namespace rego_test
       const std::string& wanted,
       std::ostream& os) const;
 
-    static void write_ast(
-      const std::filesystem::path& debug_path,
-      std::size_t index,
-      const std::string& pass,
-      const Node& ast);
     static std::optional<Node> maybe_get_file(
       const Node& mapping, const std::string& name);
     static std::optional<std::string> maybe_get_string(

--- a/tools/driver.cc
+++ b/tools/driver.cc
@@ -1,7 +1,9 @@
 #include <rego/rego.hh>
+#include <trieste/driver.h>
 
 int main(int argc, char** argv)
 {
   auto builtins = rego::BuiltIns().register_standard_builtins();
-  return rego::driver(builtins).run(argc, argv);
+  trieste::Driver driver("rego", nullptr, parser(), passes(builtins));
+  return driver.run(argc, argv);
 }

--- a/tools/driver.cc
+++ b/tools/driver.cc
@@ -4,6 +4,7 @@
 int main(int argc, char** argv)
 {
   auto builtins = rego::BuiltIns().register_standard_builtins();
-  trieste::Driver driver("rego", nullptr, parser(), passes(builtins));
+  trieste::Driver driver(
+    "rego", nullptr, rego::parser(), rego::passes(builtins));
   return driver.run(argc, argv);
 }


### PR DESCRIPTION
This removes trieste/driver.h from most files.  Which pushes the Trieste Driver header into the two tools that need it, and uses the new trieste/trieste.h instead.  This reduces the compilation time by about 30%.