### PR TITLE
Fix #ifdef macros to allow use with Werror=undef

### DIFF
--- a/src/version.h.in
+++ b/src/version.h.in
@@ -14,11 +14,11 @@
 #define REGOCPP_BUILD_DATE "@REGOCPP_BUILD_DATE@"
 #define REGOCPP_BUILD_TOOLCHAIN "@REGOCPP_BUILD_TOOLCHAIN@"
 
-#ifdef _WIN32
+#if defined(_WIN32)
 #define REGOCPP_PLATFORM "windows"
-#elif __APPLE__
+#elif defined(__APPLE__)
 #define REGOCPP_PLATFORM "macos"
-#elif __linux__
+#elif defined(__linux__)
 #define REGOCPP_PLATFORM "linux"
 #else
 #define REGOCPP_PLATFORM "other"


### PR DESCRIPTION
Under some circumstances (compiler version/platform/compilation options) the compilation of src/version.h might fail. This is on:

```
$ gcc --version
gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
Copyright (C) 2021 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
after including `<rego/rego.hh>` in a file called `RuleEvaluator.cpp`

```
[ 80%] Building CXX object [redacted]/RuleEvaluator.cpp.o
In file included from [redacted]/_deps/regocpp-src/src/../include/rego/rego_c.h:9,
                 from [redacted]/_deps/regocpp-src/src/../include/rego/rego.hh:6,
                 from [redacted]/RuleEvaluator.cpp:3:
                 [redacted]/_deps/regocpp-build/src/version.h:19:7: error: "__APPLE__" is not defined, evaluates to 0 [-Werror=undef]
   19 | #elif __APPLE__
      |       ^~~~~~~~~
```

Using `#elif defined(name)` will not cause the error even with `Werror=undef`.

I could not reproduce this in another platform (FreeBSD) with `clang15` and `clang17`.