### PR TITLE
Fixing an issue with implicit enum statement capture

### DIFF
--- a/include/rego/rego.hh
+++ b/include/rego/rego.hh
@@ -708,7 +708,7 @@ namespace rego
   inline const auto wf_pass_init =
     wf_pass_simple_refs
     | (UnifyBody <<= (Local | Literal | LiteralWith | LiteralEnum | LiteralNot | LiteralInit)++[1])
-    | (LiteralInit <<= VarSeq * VarSeq * AssignInfix)
+    | (LiteralInit <<= (Lhs >>= VarSeq) * (Rhs >>= VarSeq) * AssignInfix)
     ;
   // clang-format on
 

--- a/src/parse.cc
+++ b/src/parse.cc
@@ -1,5 +1,4 @@
 #include "internal.hh"
-#include "rego.hh"
 
 namespace rego
 {

--- a/src/passes/enumerate.cc
+++ b/src/passes/enumerate.cc
@@ -79,15 +79,19 @@ namespace
     }
   }
 
-  // Determines which statements following an implicit enum statement are needed to
-  // instantiate the item sequence for that enum and adds them to the outside list.
-  // Otherwise they should be captured by the enum and are placed in the inside list.
+  // Determines which statements following an implicit enum statement are needed
+  // to instantiate the item sequence for that enum and adds them to the outside
+  // list. Otherwise they should be captured by the enum and are placed in the
+  // inside list.
   void capture_statements(
-    const NodeRange tail, Node itemseq, std::vector<Node>& outside, std::vector<Node>& inside)
+    const NodeRange tail,
+    Node itemseq,
+    std::vector<Node>& outside,
+    std::vector<Node>& inside)
   {
     std::set<Location> vars;
     vars_from(itemseq, vars);
-    for(auto it = tail.first; it != tail.second; ++it)
+    for (auto it = tail.first; it != tail.second; ++it)
     {
       Node stmt = *it;
       if (stmt->type() == LiteralInit)
@@ -305,8 +309,7 @@ namespace rego
             auto temp = _.fresh({"enum"});
             auto item = _.fresh({"item"});
             return Seq
-              << outside
-              << (Local << (Var ^ item) << Undefined)
+              << outside << (Local << (Var ^ item) << Undefined)
               << (LiteralEnum
                   << (Var ^ item) << _(ItemSeq)
                   << (UnifyBody

--- a/src/passes/enumerate.cc
+++ b/src/passes/enumerate.cc
@@ -65,6 +65,60 @@ namespace
     auto it = unifybody->find(local) + 1;
     return find_enum(unifybody, it);
   }
+
+  void vars_from(Node node, std::set<Location>& vars)
+  {
+    if (node->type() == Var)
+    {
+      vars.insert(node->location());
+    }
+
+    for (Node child : *node)
+    {
+      vars_from(child, vars);
+    }
+  }
+
+  // Determines which statements following an implicit enum statement are needed to
+  // instantiate the item sequence for that enum and adds them to the prefix.
+  // Otherwise they should be captured by the enum and are placed in the postfix.
+  void determine_prefix_and_postfix(
+    const NodeRange tail, Node itemseq, std::vector<Node>& prefix, std::vector<Node>& postfix)
+  {
+    std::set<Location> vars;
+    vars_from(itemseq, vars);
+    for(auto it = tail.first; it != tail.second; ++it)
+    {
+      Node stmt = *it;
+      if (stmt->type() == LiteralInit)
+      {
+        std::set<Location> init_vars;
+        vars_from(stmt / Lhs, init_vars);
+        vars_from(stmt / Rhs, init_vars);
+        std::set<Location> intersection;
+        std::set_intersection(
+          vars.begin(),
+          vars.end(),
+          init_vars.begin(),
+          init_vars.end(),
+          std::inserter(intersection, intersection.begin()));
+        if (intersection.empty())
+        {
+          postfix.push_back(stmt);
+        }
+        else
+        {
+          // the item sequence depends on this init, so it must
+          // precede it.
+          prefix.push_back(stmt);
+        }
+      }
+      else
+      {
+        postfix.push_back(stmt);
+      }
+    }
+  }
 }
 
 namespace rego
@@ -170,10 +224,14 @@ namespace rego
               return err(idx, "Invalid index for enumeration");
             }
 
+            std::vector<Node> prefix;
+            std::vector<Node> postfix;
+            determine_prefix_and_postfix(_[Tail], _(ItemSeq), prefix, postfix);
+
             auto temp = _.fresh({"enum"});
             auto item = _.fresh({"item"});
             return Seq
-              << (Local << (Var ^ item) << Undefined)
+              << prefix << (Local << (Var ^ item) << Undefined)
               << (LiteralEnum
                   << (Var ^ item) << _(ItemSeq)
                   << (UnifyBody
@@ -197,7 +255,7 @@ namespace rego
                                           << (Var ^ item)
                                           << (RefArgBrack
                                               << (Scalar << (Int ^ "1"))))))))
-                      << _[Tail]));
+                      << postfix));
           },
 
         In(UnifyBody) *
@@ -240,9 +298,14 @@ namespace rego
               idx = Term << idx;
             }
 
+            std::vector<Node> prefix;
+            std::vector<Node> postfix;
+            determine_prefix_and_postfix(_[Tail], _(ItemSeq), prefix, postfix);
+
             auto temp = _.fresh({"enum"});
             auto item = _.fresh({"item"});
             return Seq
+              << prefix
               << (Local << (Var ^ item) << Undefined)
               << (LiteralEnum
                   << (Var ^ item) << _(ItemSeq)
@@ -268,7 +331,7 @@ namespace rego
                                               << (RefArgBrack
                                                   << (Scalar
                                                       << (Int ^ "1")))))))))
-                      << _[Tail]));
+                      << postfix));
           },
       }};
   }

--- a/src/passes/init.cc
+++ b/src/passes/init.cc
@@ -3,7 +3,6 @@
 #include <algorithm>
 #include <cstddef>
 #include <deque>
-#include <stdexcept>
 
 namespace
 {

--- a/src/passes/rules.cc
+++ b/src/passes/rules.cc
@@ -317,6 +317,13 @@ namespace rego
             return Seq << _[RuleRef];
           },
 
+        In(Policy) * (T(Group) << T(Var)[Var]) *
+            (T(Group) << T(UnifyBody)[UnifyBody]) >>
+          [](Match& _) {
+            ACTION();
+            return Group << _(Var) << _(UnifyBody);
+          },
+
         // errors
 
         In(Policy) * T(Group)[Group] >>

--- a/tests/regocpp.yaml
+++ b/tests/regocpp.yaml
@@ -1122,3 +1122,20 @@ cases:
       - 1
       - 2
       - 3
+- note: regocpp/bug101
+  modules:
+  - |
+    package test
+
+    x = y {
+      y = [z |
+        z = a[_]
+        a = [1, 2, 3]
+      ]
+    }
+  query: data.test.x = x
+  want_result:
+    - x:
+      - 1
+      - 2
+      - 3

--- a/tests/regocpp.yaml
+++ b/tests/regocpp.yaml
@@ -1139,3 +1139,36 @@ cases:
       - 1
       - 2
       - 3
+- note: regocpp/non-monotone
+  modules:
+  - |
+    package test
+
+    ips_by_port := {
+        80: ["1.1.1.1", "1.1.1.2"],
+        443: ["2.2.2.1"],
+    }
+
+    default foo1 := false
+    default foo2 := false
+
+    foo1
+        {
+        port = 77;
+        a = [port | ips_by_port[port][_] == "2.2.2.1" ];
+        b = [port | ips_by_port[port][_] == "1.1.1.1" ];
+        a = b
+        }
+
+    foo2
+        {
+        a = [port | ips_by_port[port][_] == "2.2.2.1" ];
+        b = [port | ips_by_port[port][_] == "1.1.1.1" ];
+        a = b
+        }
+
+  query: [data.test.foo1, data.test.foo2] = x
+  want_result:
+    - x:
+      - true
+      - false


### PR DESCRIPTION
This PR fixes an issue with enum statement capture, in which an enum could capture its own domain. Also fixed is a parser problem where rule bodies without an assignment operator that were declared on a new line were not correctly joined to their rule heads.

Fixes #101 