### PR TITLE
Allow tests to see non-binding results

### DIFF
--- a/tests/bugs.yaml
+++ b/tests/bugs.yaml
@@ -45,6 +45,12 @@ cases:
       - 1
       - 2
       - 3
+- note: regocpp/bug109
+  query: true; [1,2,3]; 2
+  want_result:
+    - true
+    - [1, 2, 3]
+    - 2
 - note: regocpp/bug110
   query: "[1, 2, 3][_] = x"
   want_result:

--- a/tests/test_case.h
+++ b/tests/test_case.h
@@ -9,6 +9,12 @@ namespace rego_test
   using BindingMap = std::map<std::string, std::string>;
   using BindingMaps = std::map<std::string, BindingMap>;
 
+  struct TermsAndBindings
+  {
+    std::vector<std::string> terms;
+    BindingMaps binding_maps;
+  };
+
   struct Result
   {
     bool passed;
@@ -87,7 +93,7 @@ namespace rego_test
     TestCase& broken(bool broken);
 
   private:
-    BindingMaps to_binding_maps(const Node& node) const;
+    const TermsAndBindings to_terms_and_bindings(const Node& node) const;
     bool compare(
       const Node& actual, const Node& wanted, std::ostream& os) const;
     bool compare(


### PR DESCRIPTION
Sometimes, a test needs to assert results that are not bindings. Issue #109 shows a query of that form, where the intended output is a series of values with no bound names at all. Currently, the test suite will ignore those results and conclude that nothing is output by the query.

Conversely, sometimes rego-cpp outputs things it shouldn't, and we can't see it do that when those things aren't bindings. Issue #142 is an example of this, where the OPA test looks like it passes because all the bindings match, but if you look at the output of running rego-cpp manually, unwanted values are there.

This PR suggests a fix for the testing situation in both of these cases: assert both the binding and non-binding results. Existing tests become more powerful (and identify #142 correctly), and we can write tests for #109.

Well, in principle.
It turns out that the tests can't actually detect the problem described in #109 because the reordering happens at an output stage not exercised by the test system. The new test for #109 passes in this branch because of that, so we need a different kind of test to detect that. Still, it's a start.

Note: #147 changes the output format, fixing #109. It does not fix #142, however. This testing change still makes that issue visible.