### PR TITLE
Minor changes to fix the python wheel builds

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           path: ./wheelhouse/*.whl
   build_mac_wheels:
-    name: Build wheels on Mac
+    name: Build wheels on mac
     runs-on: macos-latest
     strategy:
       matrix:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -31,42 +31,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-
-  build_macos_wheels:
-    name: Build wheels on mac
+  build_mac_wheels:
+    name: Build wheels on Mac
     runs-on: macos-latest
-    strategy:
-      matrix:
-        python: [cp39, cp310, cp311, cp312, pp39, pp310]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Git config for fetching pull requests
-        run: |
-          git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v2.18.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-macosx*
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_ENVIRONMENT_MACOS : >
-            MACOSX_DEPLOYMENT_TARGET=10.15
-            CC=gcc-11
-            CXX=g++-11
-            REGOCPP_REPO=https://github.com/${{github.repository}}
-            REGOCPP_TAG=${{github.sha}}
-        with:
-          package-dir: ${{github.workspace}}/wrappers/python/
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
-
-  build_apple_silicon_wheels:
-    name: Build wheels on Apple Silicon
-    runs-on: macos-latest-xlarge
     strategy:
       matrix:
         python: [cp310, cp311, cp312]
@@ -108,7 +75,6 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
-
   build_manylinux_wheels:
     name: Build wheels on manylinux
     runs-on: ubuntu-latest

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -19,7 +19,7 @@ jobs:
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-win*
           CIBW_ENVIRONMENT: >
@@ -47,7 +47,7 @@ jobs:
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-macosx*
           CIBW_ARCHS_MACOS: x86_64
@@ -94,7 +94,7 @@ jobs:
           export PATH=$(python3 -m site --user-base)/bin:$PATH
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-macosx*
           CIBW_ARCHS_MACOS: arm64
@@ -124,7 +124,7 @@ jobs:
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-manylinux*
           CIBW_BEFORE_ALL: yum makecache && yum -y install devtoolset-10-libatomic-devel
@@ -153,7 +153,7 @@ jobs:
           git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.18.1
         env:
           CIBW_BUILD: ${{ matrix.python }}-musllinux*
           CIBW_ENVIRONMENT: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   trieste
-  GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG        27b11771a0c07fca676e5d515f6cde61ece5117c
+  GIT_REPOSITORY https://github.com/matajoh/trieste
+  GIT_TAG        6361519183ebab8978d72eaf1e37558a71832d2d
 )
 
 FetchContent_MakeAvailable(cmake_utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,8 +92,8 @@ FetchContent_Declare(
 
 FetchContent_Declare(
   trieste
-  GIT_REPOSITORY https://github.com/matajoh/trieste
-  GIT_TAG        4bdcd3e74f782854dfa3613385c0dde6ba52fd45
+  GIT_REPOSITORY https://github.com/microsoft/trieste
+  GIT_TAG        c0234a5102fbc8ec84993dabcdbecedac82095d9
 )
 
 FetchContent_MakeAvailable(cmake_utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/matajoh/trieste
-  GIT_TAG        6361519183ebab8978d72eaf1e37558a71832d2d
+  GIT_TAG        4bdcd3e74f782854dfa3613385c0dde6ba52fd45
 )
 
 FetchContent_MakeAvailable(cmake_utils)

--- a/src/builtins/graph.cc
+++ b/src/builtins/graph.cc
@@ -292,6 +292,6 @@ namespace rego
         BuiltInDef::create(
           Location("graph.reachable_paths"), 2, reachable_paths),
       };
-    };
+    }
   }
 }


### PR DESCRIPTION
- No more x86 mac builds
- Stray semicolons
- Bumping the version of cibuildwheel