### PR TITLE
Update Trieste and fix API breakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ FetchContent_Declare(
 FetchContent_Declare(
   trieste
   GIT_REPOSITORY https://github.com/microsoft/trieste
-  GIT_TAG        7cd90387ac2de6423ed1dc43496273b0a20a03d4
+  GIT_TAG        d51038b8392220637ce912e12fffc2c86715e54b
 )
 
 FetchContent_MakeAvailable(cmake_utils)

--- a/src/internal.cc
+++ b/src/internal.cc
@@ -88,7 +88,7 @@ namespace rego
       return false;
     }
 
-    return is_in(node->parent()->shared_from_this(), types);
+    return is_in(node->parent()->intrusive_ptr_from_this(), types);
   }
 
   bool is_constant(const Node& term)

--- a/src/rego_c.cc
+++ b/src/rego_c.cc
@@ -552,7 +552,7 @@ extern "C"
     logging::Debug() << "regoNodeJSONSize";
     auto node_ptr = reinterpret_cast<trieste::NodeDef*>(node);
     trieste::WFContext context(rego::wf_result);
-    std::string json = rego::to_key(node_ptr->shared_from_this(), true);
+    std::string json = rego::to_key(node_ptr->intrusive_ptr_from_this(), true);
     return static_cast<regoSize>(json.size() + 1);
   }
 
@@ -562,7 +562,7 @@ extern "C"
 
     auto node_ptr = reinterpret_cast<trieste::NodeDef*>(node);
     trieste::WFContext context(rego::wf_result);
-    std::string json = rego::to_key(node_ptr->shared_from_this(), true);
+    std::string json = rego::to_key(node_ptr->intrusive_ptr_from_this(), true);
     if (size < json.size() + 1)
     {
       return REGO_ERROR_BUFFER_TOO_SMALL;

--- a/src/unify.cc
+++ b/src/unify.cc
@@ -67,7 +67,7 @@ namespace rego
       return name.find("query$") != std::string::npos;
     }
 
-    return in_query(node->parent()->shared_from_this());
+    return in_query(node->parent()->intrusive_ptr_from_this());
   }
 
   bool contains_local(const Node& node)

--- a/src/unify/absolute_refs.cc
+++ b/src/unify/absolute_refs.cc
@@ -21,7 +21,7 @@ namespace
       return Ref << (RefHead << (Var ^ "data")) << refargseq;
     }
 
-    Node ref = build_ref(leaf->parent()->shared_from_this());
+    Node ref = build_ref(leaf->parent()->intrusive_ptr_from_this());
 
     if (leaf->type() == Policy || leaf->type() == DataModule)
     {

--- a/src/unify/enumerate.cc
+++ b/src/unify/enumerate.cc
@@ -61,7 +61,7 @@ namespace
 
   Node next_enum(Node local)
   {
-    Node unifybody = local->parent()->shared_from_this();
+    Node unifybody = local->parent()->intrusive_ptr_from_this();
     auto it = unifybody->find(local) + 1;
     return find_enum(unifybody, it);
   }
@@ -302,7 +302,7 @@ namespace rego
       if (is_in(local, {LiteralEnum}))
       {
         // should this local be defined here?
-        Node unifybody = local->parent()->shared_from_this();
+        Node unifybody = local->parent()->intrusive_ptr_from_this();
         bool requires_move = false;
         while (!should_be_defined_in(local, unifybody))
         {
@@ -316,7 +316,7 @@ namespace rego
             break;
           }
 
-          unifybody = literalenum->parent()->shared_from_this();
+          unifybody = literalenum->parent()->intrusive_ptr_from_this();
         }
 
         if (requires_move)

--- a/src/unify/lift_refheads.cc
+++ b/src/unify/lift_refheads.cc
@@ -215,7 +215,7 @@ namespace
         return;
       }
 
-      Node module = node->parent()->parent()->shared_from_this();
+      Node module = node->parent()->parent()->intrusive_ptr_from_this();
       Node prefix_ref = concat_refs(Var ^ "data", (module / Package)->front());
       if (prefix_ref->type() == Error)
       {
@@ -316,7 +316,8 @@ namespace rego
         }) >>
           [refheads](Match& _) {
             ACTION();
-            Node module = _(Rule)->parent()->parent()->shared_from_this();
+            Node module =
+              _(Rule)->parent()->parent()->intrusive_ptr_from_this();
             Node imports = (module / ImportSeq)->clone();
             Node package_ref = (module / Package)->front();
             Node version = (module / Version)->clone();
@@ -374,7 +375,7 @@ namespace rego
     });
 
     lift_refheads.post(Rule, [refheads](Node node) {
-      Node module = node->parent()->parent()->shared_from_this();
+      Node module = node->parent()->parent()->intrusive_ptr_from_this();
       Node rulehead = node / RuleHead;
       Node package_ref = (module / Package)->front();
       Node prefix_ref = concat_refs(Var ^ "data", package_ref);

--- a/src/unify/lift_to_rule.cc
+++ b/src/unify/lift_to_rule.cc
@@ -151,7 +151,7 @@ namespace
         return (*it)->clone();
       }
 
-      return err(node->shared_from_this(), "Missing version");
+      return err(node->intrusive_ptr_from_this(), "Missing version");
     }
 
     return get_version(node->parent());

--- a/src/unify/symbols.cc
+++ b/src/unify/symbols.cc
@@ -39,7 +39,8 @@ namespace
     auto it = module->find_first(Version, module->begin());
     if (it == module->end())
     {
-      return err(module->shared_from_this(), "No version found in module");
+      return err(
+        module->intrusive_ptr_from_this(), "No version found in module");
     }
     return (*it)->clone();
   }


### PR DESCRIPTION
After Trieste's recent intrusive refcount change, uses of `->shared_from_this()` broke.

This PR shows the changes needed for fix that.

For broader discussion (don't merge yet!):
- seems my change to Trieste added tests in a way that breaks in dependencies. Oops, will fix.
- As part of intrusive_ptr discussion, there were thoughts of making `->parent()` return a `Node` instead of a `NodeDef*`