### PR TITLE
Remove now-unncessary GitHub Actions image workaround

### DIFF
--- a/.github/workflows/pr_gate.yml
+++ b/.github/workflows/pr_gate.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: mjp41/workaround8649@c8550b715ccdc17f89c8d5c28d7a48eeff9c94a8
-
       - name: Get dependencies
         run: |
           sudo apt-get install ninja-build
@@ -61,8 +59,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: mjp41/workaround8649@c8550b715ccdc17f89c8d5c28d7a48eeff9c94a8
-
       - name: Get dependencies
         run: |
           sudo apt-get install ninja-build
@@ -84,8 +80,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - uses: mjp41/workaround8649@c8550b715ccdc17f89c8d5c28d7a48eeff9c94a8
 
       - name: Get dependencies
         run: |
@@ -174,8 +168,6 @@ jobs:
         with:
           repository: CHERIoT-Platform/cheriot-audit
           path: cheriot-audit
-
-      - uses: mjp41/workaround8649@c8550b715ccdc17f89c8d5c28d7a48eeff9c94a8
 
       - name: Get dependencies
         run: |


### PR DESCRIPTION
Resolved by https://github.com/actions/runner-images/issues/9679, and became irrelevant since https://github.com/actions/runner-images/issues/10636 too.