### PR TITLE
Build Python wheels from one matrix

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -4,12 +4,76 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_windows_wheels:
-    name: Build wheels on windows
-    runs-on: windows-latest
+  build_wheels:
+    name: Build ${{ matrix.python }} wheels for ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         python: [cp39, cp310, cp311, cp312, cp313, cp314]
+        target:
+          - windows
+          - macos-arm64
+          - macos-x86_64
+          - manylinux-x86_64
+          - manylinux-aarch64
+          - musllinux-x86_64
+          - musllinux-aarch64
+        exclude:
+          - python: cp39
+            target: macos-arm64
+          - python: cp39
+            target: macos-x86_64
+        include:
+          - target: windows
+            runner: windows-latest
+            archs: AMD64
+            build: "win*"
+            before_all: ""
+            environment: ""
+            macos_deployment_target: ""
+          - target: macos-arm64
+            runner: macos-latest
+            archs: arm64
+            build: "macosx*"
+            before_all: brew install openssl@3
+            environment: "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
+            macos_deployment_target: "15.0"
+          - target: macos-x86_64
+            runner: macos-15-intel
+            archs: x86_64
+            build: "macosx*"
+            before_all: brew install openssl@3
+            environment: "OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)"
+            macos_deployment_target: "15.0"
+          - target: manylinux-x86_64
+            runner: ubuntu-latest
+            archs: x86_64
+            build: "manylinux*"
+            before_all: dnf makecache && dnf install -y openssl-devel
+            environment: ""
+            macos_deployment_target: ""
+          - target: manylinux-aarch64
+            runner: ubuntu-24.04-arm
+            archs: aarch64
+            build: "manylinux*"
+            before_all: dnf makecache && dnf install -y openssl-devel
+            environment: ""
+            macos_deployment_target: ""
+          - target: musllinux-x86_64
+            runner: ubuntu-latest
+            archs: x86_64
+            build: "musllinux*"
+            before_all: apk add openssl-dev
+            environment: ""
+            macos_deployment_target: ""
+          - target: musllinux-aarch64
+            runner: ubuntu-24.04-arm
+            archs: aarch64
+            build: "musllinux*"
+            before_all: apk add openssl-dev
+            environment: ""
+            macos_deployment_target: ""
 
     steps:
       - uses: actions/checkout@v6
@@ -21,172 +85,28 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.4.1
         env:
-          CIBW_BUILD: ${{ matrix.python }}-win*
+          CIBW_ARCHS: ${{ matrix.archs }}
+          CIBW_BEFORE_ALL: ${{ matrix.before_all }}
+          CIBW_BUILD: ${{ matrix.python }}-${{ matrix.build }}
           CIBW_ENVIRONMENT: >
             REGOCPP_REPO=https://github.com/${{github.repository}}
             REGOCPP_TAG=${{github.sha}}
-        with:
-          package-dir: ${{github.workspace}}/wrappers/python/
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.python }}-windows
-          path: ./wheelhouse/*.whl
-  build_mac_wheels:
-    name: Build wheels on macos/arm64
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        python: [cp310, cp311, cp312, cp313, cp314]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        id: python
-        with:
-          python-version: "3.10 - 3.13"
-          update-environment: false
-      
-      - name: Git config for fetching pull requests
-        run: |
-          git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
-
-      - name: Fix path
-        run: |
-          export PATH=$(python3 -m site --user-base)/bin:$PATH
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-macosx*
-          CIBW_ARCHS_MACOS: arm64
-          MACOSX_DEPLOYMENT_TARGET: "15.0"
-          CIBW_BEFORE_ALL_MACOS: brew install openssl@3
-          CIBW_ENVIRONMENT_MACOS : >
-            REGOCPP_REPO=https://github.com/${{github.repository}}
-            REGOCPP_TAG=${{github.sha}}
-            OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
-        with:
-          package-dir: ${{github.workspace}}/wrappers/python/
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.python }}-mac-arm64
-          path: ./wheelhouse/*.whl
-  build_mac_intel_wheels:
-    name: Build wheels on macos/x86_64
-    runs-on: macos-15-intel
-    strategy:
-      matrix:
-        python: [cp310, cp311, cp312, cp313, cp314]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-python@v6
-        id: python
-        with:
-          python-version: "3.10 - 3.13"
-          update-environment: false
-      
-      - name: Git config for fetching pull requests
-        run: |
-          git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
-
-      - name: Fix path
-        run: |
-          export PATH=$(python3 -m site --user-base)/bin:$PATH
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-macosx*
-          CIBW_ARCHS_MACOS: x86_64
-          MACOSX_DEPLOYMENT_TARGET: "15.0"
-          CIBW_BEFORE_ALL_MACOS: brew install openssl@3
-          CIBW_ENVIRONMENT_MACOS : >
-            REGOCPP_REPO=https://github.com/${{github.repository}}
-            REGOCPP_TAG=${{github.sha}}
-            OPENSSL_ROOT_DIR=$(brew --prefix openssl@3)
-        with:
-          package-dir: ${{github.workspace}}/wrappers/python/
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.python }}-mac-x86_64
-          path: ./wheelhouse/*.whl
-  build_manylinux_wheels:
-    name: Build wheels on manylinux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [cp39, cp310, cp311, cp312, cp313, cp314]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Git config for fetching pull requests
-        run: |
-          git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-manylinux*
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
+            ${{ matrix.environment }}
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_34
-          CIBW_BEFORE_ALL: dnf makecache && dnf install -y openssl-devel
-          CIBW_ENVIRONMENT: >
-            REGOCPP_REPO=https://github.com/${{github.repository}}
-            REGOCPP_TAG=${{github.sha}}
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_34
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_deployment_target }}
         with:
           package-dir: ${{github.workspace}}/wrappers/python/
 
       - uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ matrix.python }}-manylinux
-          path: ./wheelhouse/*.whl
-
-  build_musllinux_wheels:
-    name: Build wheels on musllinux
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python: [cp39, cp310, cp311, cp312, cp313, cp314]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Git config for fetching pull requests
-        run: |
-          git config --global --add remote.origin.fetch +refs/pull/*/merge:refs/remotes/pull/*
-
-      - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4.1
-        env:
-          CIBW_BUILD: ${{ matrix.python }}-musllinux*
-          CIBW_BEFORE_ALL: apk add openssl-dev
-          CIBW_ENVIRONMENT: >
-            REGOCPP_REPO=https://github.com/${{github.repository}}
-            REGOCPP_TAG=${{github.sha}}
-        with:
-          package-dir: ${{github.workspace}}/wrappers/python/
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: wheels-${{ matrix.python }}-musllinux
+          name: wheels-${{ matrix.python }}-${{ matrix.target }}
           path: ./wheelhouse/*.whl
 
   merge:
-      needs:
-        - build_windows_wheels
-        - build_mac_wheels
-        - build_mac_intel_wheels
-        - build_manylinux_wheels
-        - build_musllinux_wheels
-      runs-on: ubuntu-latest
-      steps:
+    needs: build_wheels
+    runs-on: ubuntu-latest
+    steps:
       - name: Download Wheels
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
The release workflow repeats the same checkout, cibuildwheel, and
artifact steps across five jobs. Replace those jobs with Python and
wheel-target matrix axes while preserving the existing Windows, macOS,
and Linux wheel combinations.

The v1.3.1 release configured an aarch64 manylinux image but left the
Linux jobs on x86_64 runners. Complete that intended support by running
both Linux wheel targets on native x86_64 and aarch64 runners. The next
release will publish manylinux and musllinux aarch64 wheels instead of
falling back to source builds on aarch64.

Fixes #218.