### PR TITLE
Pin source builds to the release tag

### DIFF
--- a/wrappers/python/setup.py
+++ b/wrappers/python/setup.py
@@ -71,7 +71,7 @@ class CMakeBuild(build_ext):
             if repo == "LOCAL":
                 src_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir))
             else:
-                tag = os.environ.get("REGOCPP_TAG", "main")
+                tag = os.environ.get("REGOCPP_TAG", f"v{VERSION}")
 
                 subprocess.check_call(["git", "clone", repo, src_path])
                 subprocess.check_call(["git", "checkout", tag], cwd=src_path)


### PR DESCRIPTION
Building regopy from an sdist currently clones rego-cpp and checks out
main when `REGOCPP_TAG` is unset. Rebuilding the same regopy release can
therefore compile different native code as main advances.

Default the checkout to `v{VERSION}`, matching the repository release
tag convention. Explicit overrides are unchanged, including the commit
SHA supplied by `build_wheels.yml`.